### PR TITLE
Add GitHub Actions test automation on PRs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,43 @@
+name: Test Python code
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install package
+        run: pip install -e .
+
+      - name: Install test runner
+        run: pip install pytest pytest-cov
+
+      - name: Install legacy test runner
+        run: pip install nose
+
+      - name: Install patched mir_eval dependency
+        run: pip install --force-reinstall --no-dependencies git+https://github.com/craffel/mir_eval@d68afb0b37bfd0ff48a92fbe1ae1325a182cd471
+
+      - name: Run unit tests
+        run: pytest --cov=msaf
+        working-directory: tests


### PR DESCRIPTION
### What?

Introduce automated testing on PRs by GitHub Actions.

### Why?

To make PR reviews easier by checking that unit tests pass automatically on fresh installations of MSAF.

### How?

1. Introduce a workflow YAML for GitHub Actions that triggers on pull request changes or pushes to the master branch.
1. Headbutting with dependencies.